### PR TITLE
Reorder gcc parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CFLAGS = -g -O2 -Wall -lusb-1.0 -I/usr/include/libusb-1.0
 all:	pcsensor
 
 pcsensor:	pcsensor.c
-	${CC} ${CFLAGS} -DUNIT_TEST -o $@ $^
+	${CC} $^ ${CFLAGS} -DUNIT_TEST -o $@
 
 clean:		
 	rm -f pcsensor *.o


### PR DESCRIPTION
Found linker unable to resolve libusb functions because of current parameter ordering. This reordering should help create the undefined symbols first, which subsequently resolve when it reaches libusb-1.0.a