### PR TITLE
Use memset() instead of bzero()

### DIFF
--- a/pcsensor.c
+++ b/pcsensor.c
@@ -269,7 +269,7 @@ void control_transfer(libusb_device_handle *dev, const char *pquestion) {
 
 void interrupt_read(libusb_device_handle *dev, unsigned char *answer) {
     int r,s,i;
-    bzero(answer, reqIntLen);
+    memset(answer, 0, reqIntLen);
 
     s = libusb_interrupt_transfer(dev, endpoint_Int_in, answer, reqIntLen, &r, timeout);
     if(r != reqIntLen) {


### PR DESCRIPTION
- The function bzero() is deprecated (marked as LEGACY in POSIX.1-2001)
  use memset() in new programs. POSIX.1-2008 removes the specification
  of bzero(). From: https://linux.die.net/man/3/bzero
- Furthermore, this fixes the compiler warning using MinGW-w64:
  `pcsensor.c:272:5: warning: implicit declaration of function 'bzero'`
  `[-Wimplicit-function-declaration] bzero(answer, reqIntLen);`