### PR TITLE
Update libusb-1.0 include

### DIFF
--- a/pcsensor.c
+++ b/pcsensor.c
@@ -39,7 +39,7 @@
 #include <strings.h>
 #include <errno.h>
 #include <signal.h>
-#include <libusb.h>
+#include <libusb-1.0/libusb.h>
 
 #define VERSION "1.2.0"
 


### PR DESCRIPTION
- Use `#include <libusb-1.0/libusb.h>`
- Fixes MinGW-w64 compile error:
  `pcsensor.c:42:10: fatal error: libusb.h: No such file or directory`